### PR TITLE
CI: create wheels not only for python 2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   CIBW_BEFORE_BUILD: "pip install cython"
-  CIBW_BUILD: cp27-*
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
       APPVEYOR_JOB_NAME: "python37-x64-ubuntu"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
         - CIBW_TEST_REQUIRES=pytest
         - CIBW_TEST_COMMAND="cd {project} && python {project}/setup.py test"
         - CIBW_BEFORE_BUILD="pip install cython"
-        - CIBW_BUILD=cp27-*
         #- CIBW_BUILD_VERBOSITY=-3
         - TESTS=0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,12 @@ jobs:
       python: 2.7
       env: TESTS=1
     - os: linux
+      python: 3.5
+      env: TESTS=1
+    - os: linux
+      python: 3.6
+      env: TESTS=1
+    - os: linux
       python: 3.7
       env: TESTS=1
     - os: linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Release notes
 ---------------------
 
 - Python 3 compatible (CI, code, tests)
+- Code: use `std::fmod` instead of `std::remainder` only for Visual C++ 9.0 (Windows & python 2.7)
 - Doc: add a release section
 - Setup: use ``bumpversion`` to bump the version easily
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@ Release notes
 1.2.dev0 (unreleased)
 ---------------------
 
-- Code: python 3 compatible
+- Python 3 compatible (CI, code, tests)
 - Doc: add a release section
 - Setup: use ``bumpversion`` to bump the version easily
-- Tests: python 3 compatible
 
 
 1.1 (2020-04-10)

--- a/pypitch/pitch.cpp
+++ b/pypitch/pitch.cpp
@@ -21,7 +21,10 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
+// Visual Studio C++ 9.0 / python 2.7
+#if (_MSC_VER == 1500)
 #define remainder fmod
+#endif
 #endif
 
 #include "pitch.hpp"


### PR DESCRIPTION
Use python 3.8 for Windows too.
Windows: use `fmod` only with Visual C++ 9.0 (2008) (python 2.7). `remainder` were [introduced in VS 2015](https://docs.microsoft.com/en-us/cpp/porting/visual-cpp-change-history-2003-2015?view=vs-2019#mathh).