### PR TITLE
ci: drop old python3 versions (3.5 & 3.6)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+        python-version: [2.7, 3.7, 3.8, 3.9]
 
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Release notes
 2.0 (unreleased)
 ----------------
 
+- build: drop python 3.6 support
+
 
 1.3 (2020-12-17)
 ----------------

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Tests](https://github.com/fofix/python-pypitch/workflows/Tests/badge.svg?branch=master)](https://github.com/fofix/python-pypitch/actions?query=workflow:Test)
 [![Build status](https://ci.appveyor.com/api/projects/status/0f6yb99cd37v6li6?svg=true)](https://ci.appveyor.com/project/Linkid/python-pypitch)
 [![Documentation Status](https://readthedocs.org/projects/pypitch/badge/?version=latest)](http://pypitch.readthedocs.io/en/latest/?badge=latest)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/pypitch.svg)](https://pypi.python.org/pypi/pypitch)
 
 
 PyPitch is a C++-extension in Python to analyse audio streams for pitch.

--- a/setup.py
+++ b/setup.py
@@ -71,8 +71,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -91,11 +89,17 @@ setup(
         "pytest<5;python_version<'3.4'",
         "pytest;python_version>'3.4'",
         "numpy<1.17;python_version<'3.4'",
-        "numpy<1.20;python_version=='3.6'",
-        "numpy;python_version>'3.6'",
+        "numpy<1.22;python_version=='3.7'",
+        "numpy;python_version>'3.7'",
     ],
     extras_require={
-        'tests': ["pytest<5;python_version<'3.4'", "pytest;python_version>'3.4'", "numpy<1.17;python_version<'3.4'", "numpy<1.20;python_version=='3.6'", "numpy;python_version>'3.6'"],
+        'tests': [
+            "pytest<5;python_version<'3.4'",
+            "pytest;python_version>'3.4'",
+            "numpy<1.17;python_version<'3.4'",
+            "numpy<1.22;python_version=='3.7'",
+            "numpy;python_version>'3.7'"
+        ],
         'docs': ['sphinx', 'sphinx_rtd_theme'],
     },
 )


### PR DESCRIPTION
Since numpy 1.22, python 3.7 is not supported.