### PR TITLE
ci(tests): use pytest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Visual C++ for Python 2.7
-        if: runner.os == 'Windows' && runner.python-version == '2.7'
+        if: runner.os == 'Windows' && matrix.python-version == '2.7'
         run: |
           choco install vcpython27 -f -y
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,9 +31,10 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install cython
           python -m pip install pytest
+          python -m pip install "numpy<1.17;python_version<'3.4'" "numpy<1.22;python_version=='3.7'" "numpy;python_version>'3.7'"
 
       - name: Test the lib
         run: |
           python setup.py build_ext --inplace --force
           python setup.py check
-          python setup.py test
+          pytest .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Release notes
 ----------------
 
 - build: drop python 3.6 support
+- build: remove `pytest-runner` from setup requirements
 
 
 1.3 (2020-12-17)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[aliases]
-test = pytest
-
 [build_sphinx]
 all_files = 1
 source-dir = doc/source

--- a/setup.py
+++ b/setup.py
@@ -84,14 +84,6 @@ setup(
     install_requires=[
         'Cython >= 0.27',
     ],
-    test_suite="tests",
-    tests_require=[
-        "pytest<5;python_version<'3.4'",
-        "pytest;python_version>'3.4'",
-        "numpy<1.17;python_version<'3.4'",
-        "numpy<1.22;python_version=='3.7'",
-        "numpy;python_version>'3.7'",
-    ],
     extras_require={
         'tests': [
             "pytest<5;python_version<'3.4'",

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
     ],
     keywords='pitch audio',
     ext_modules=cythonize(ext, compiler_directives={'language_level': sys.version_info[0]}),
-    setup_requires=['cython', 'pytest-runner'],
+    setup_requires=['cython'],
     install_requires=[
         'Cython >= 0.27',
     ],


### PR DESCRIPTION
`pytest-runner` is not needed anymore.

Ref #19